### PR TITLE
Remove duplicate repositories in list

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "gitstash",
     "displayName": "Git Stash",
     "description": "Give extra stash abilities to Code. Visually browse stashes, review and extract changes. Get all stash commands and more.",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "publisher": "arturock",
     "license": "MIT",
     "icon": "resources/logo.png",

--- a/src/Git.ts
+++ b/src/Git.ts
@@ -89,7 +89,9 @@ export default class Git {
                 continue;
             }
 
-            paths.push(gitPath);
+            if(paths.indexOf(gitPath) === -1) {
+                paths.push(gitPath);
+            }
 
             if (firstOnly) {
                 break;


### PR DESCRIPTION
Prevents repository duplicating if vscode workspaces has common repository(-ies)

Bug:
<img width="302" alt="Extension: Git Stash — flatfy (Workspace) 2019-05-13 18-39-43" src="https://user-images.githubusercontent.com/2184318/57634707-85bc9a00-75ae-11e9-8cc7-293f43c5f6f5.png">
