### PR TITLE
Fix typo

### DIFF
--- a/src/Commands.ts
+++ b/src/Commands.ts
@@ -141,7 +141,7 @@ export class Commands {
             .showQuickPick([
                 {
                     label: 'Stash only',
-                    description: 'Crate a simple stash',
+                    description: 'Create a simple stash',
                     type: StashCommands.StashType.Simple,
                 },
                 {


### PR DESCRIPTION
missing e in 'Stash only' command description: 'Crate a simple stash'