### PR TITLE
fix: minor typo in tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -238,7 +238,7 @@
             },
             {
                 "command": "gitstash.createSingle",
-                "title": "Apply contents form this file",
+                "title": "Apply contents from this file",
                 "category": "GitStash",
                 "icon": {
                     "light": "resources/icons/light/check.svg",


### PR DESCRIPTION
I noticed that there's a typo in the tooltip when hovering over the checkmark to apply a file from a stash:
![tooltip-typo](https://user-images.githubusercontent.com/7691217/94086999-cbf05300-fdc9-11ea-826e-11936950b8d5.png)


I figured it probably doesn't need to be included in the changelog, but lemme know if you want me to